### PR TITLE
fix: 参数包含 null 的时候需要被过滤；增加 script 标签支持

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,10 @@ export const g = (selector = '', opt = {}) => (...cttArr) => {
   cttArr.forEach(val => {
     if (isEle(val)) {
       el.appendChild(val)
-    } else if (val !== undefined && val !== false && !isFn(val)) {
+    } else if (val !== undefined && val !== null && val !== false && !isFn(val)) {
       const TAG = tag.toLowerCase()
       if (TAG === 'img') el.setAttribute('src', val)
+      else if (TAG === 'script') el.setAttribute('src', val)
       else if (TAG === 'input') el.value = val
       else el.insertAdjacentHTML('beforeend', val)
     }


### PR DESCRIPTION
g(tag)(val1, val2, val3...) 这种方式调用 undefined 和 null 应该是等价的，由于 undefined 反而不太主动声明，不太方便。

另外，可以支持使用 g('script')('some code src')， 这个也是比较方便动态添加远程的库。这样写也等价于 g('script', { src: 'some code src' })()，但前一种明显要方便一点。